### PR TITLE
Removed fixed width from icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -338,21 +338,21 @@
           <h2>Key Features</h2>
           <div class="features">
               <div class="feature-item">
-                  <img src="static/images/global.webp" alt="Global Coverage Icon" style="width: 80px; height: 80px; display: block; margin: 0 auto;"> <!-- Updated icon -->
+                  <img src="static/images/global.webp" alt="Global Coverage Icon" style="height: 80px; display: block; margin: 0 auto;"> <!-- Updated icon -->
                   <h3>Global Coverage</h3>
                   <p>
                       The extensive geographic coverage and large amount of data allows for the development of models that can generalize well to different agricultural practices and field types.
                   </p>
               </div>
               <div class="feature-item">
-                  <img src="static/images/ml.webp" alt="ML-Ready Icon" style="width: 80px; height: 80px; display: block; margin: 0 auto;"> <!-- Updated icon -->
+                  <img src="static/images/ml.webp" alt="ML-Ready Icon" style="height: 80px; display: block; margin: 0 auto;"> <!-- Updated icon -->
                   <h3>User-Friendly</h3>
                   <p>
                       The dataset is well-structured with great documentation and tools so that any AI/ML researcher can immediately experiment and build models, even without geospatial expertise.
                   </p>
               </div>
               <div class="feature-item">
-                  <img src="static/images/open.webp" alt="Open Ecosystem Icon" style="width: 80px; height: 80px; display: block; margin: 0 auto;"> <!-- Updated icon -->
+                  <img src="static/images/open.webp" alt="Open Ecosystem Icon" style="height: 80px; display: block; margin: 0 auto;"> <!-- Updated icon -->
                   <h3>An Open Ecosystem</h3>
                   <p>
                       FTW is built with a number of open building blocks so that it is easy for a variety of individuals and organizations to contribute their data, software, compute, and expertise.


### PR DESCRIPTION
The .webp icon files aren't squares so setting both height and width distorts them vertically.

After
![image](https://github.com/user-attachments/assets/f3fc3dbb-7ca9-4da7-880b-09f05fd4628e)

Before
![image](https://github.com/user-attachments/assets/e314f408-ef54-4a07-ac85-5b3ca80fdf7d)
